### PR TITLE
Fix enableLocalDataStore must be called after initialize

### DIFF
--- a/packages/parse-react-native/src/index.ts
+++ b/packages/parse-react-native/src/index.ts
@@ -7,7 +7,7 @@ export * from '@parse/react-base';
 
 export const initializeParse = (serverURL: string, applicationId: string, javascriptKey: string) => {
   Parse.setAsyncStorage(AsyncStorage);
-  Parse.enableLocalDatastore();
   Parse.serverURL = serverURL;
   Parse.initialize(applicationId, javascriptKey);
+  Parse.enableLocalDatastore();
 };

--- a/packages/parse-react-ssr/src/index.ts
+++ b/packages/parse-react-ssr/src/index.ts
@@ -14,11 +14,11 @@ if ((process as any).browser) {
 }
 
 export const initializeParse = (serverURL: string, applicationId: string, javascriptKey: string) => {
+  Parse.serverURL = serverURL;
+  Parse.initialize(applicationId, javascriptKey);
   if (!isServer) {
     Parse.enableLocalDatastore();
   }
-  Parse.serverURL = serverURL;
-  Parse.initialize(applicationId, javascriptKey);
 };
 
 export interface EncodedParseQuery {

--- a/packages/parse-react/src/index.ts
+++ b/packages/parse-react/src/index.ts
@@ -5,7 +5,7 @@ global.Parse = Parse;
 export * from '@parse/react-base';
 
 export const initializeParse = (serverURL: string, applicationId: string, javascriptKey: string) => {
-  Parse.enableLocalDatastore();
   Parse.serverURL = serverURL;
   Parse.initialize(applicationId, javascriptKey);
+  Parse.enableLocalDatastore();
 };


### PR DESCRIPTION
In a react-native environment, we are encountering this warning and it is fixed by `enableLocalDatastore` after `initialize`.

![image](https://user-images.githubusercontent.com/14947957/142007706-03bbb4d3-4249-4a88-9476-0ca3090416b2.png)
