### PR TITLE
:bug: fix useParseQuery will always open livequery

### DIFF
--- a/packages/parse-react-ssr/src/index.ts
+++ b/packages/parse-react-ssr/src/index.ts
@@ -137,8 +137,8 @@ export const useParseQuery = <T extends Parse.Object<Parse.Attributes>>(
     decodedQuery,
     {
       enabled: options && options.enabled || undefined,
-      enableLocalDatastore: options && options.enableLocalDatastore || undefined,
-      enableLiveQuery: options && options.enableLiveQuery || undefined,
+      enableLocalDatastore: (options && options.enableLocalDatastore) ?? undefined,
+      enableLiveQuery: (options && options.enableLiveQuery) ?? undefined,
       initialLoad: options && options.initialLoad ||
         findResult && {
           results: findResultResults,


### PR DESCRIPTION
options.enableLiveQuery && options.enableLocalDatastore