### PR TITLE
fixed EncodedParseQuery interface for react-ssr package

### DIFF
--- a/packages/parse-react-ssr/src/index.ts
+++ b/packages/parse-react-ssr/src/index.ts
@@ -24,7 +24,7 @@ export const initializeParse = (serverURL: string, applicationId: string, javasc
 export interface EncodedParseQuery {
   className: string,
   query: object,
-  findResult?: object,
+  findResult?: [] | object[],
   findError?: object
 }
 


### PR DESCRIPTION
The main problem that I found is wrong type for key "findResult?" inside interface EncodedParseQuery.

encodeParseQuery.findResult is always returns an array - empty array if nothing was founded or array of objects if query has a results.

Environment: NextJS, TypeScript